### PR TITLE
Single lambda

### DIFF
--- a/qatf.R
+++ b/qatf.R
@@ -7,19 +7,17 @@ install_github("glmgen/genlasso")
 
 library(detrendr)
 # trace(get_model, edit=TRUE)
-library(genlasso)
 library(glmgen)
+
+rm(list = ls())
 
 MSE <- function(a, b){
   len = length(a)
   return(norm(a - b, type="2")**2/len) 
 }
 
-lambda_list <- 10**seq(-3, 4.5, length.out=50)
-
-lambda <- 5
-tau <- c(0.9)
-n <- 5000
+tau <- c(0.5)
+n <- 1000
 d <- 10
 
 
@@ -28,7 +26,7 @@ d <- 10
 x <- seq(1, n, 1)
 
 # get sceneria 1, 2, 3
-# x <- x/n
+x <- x/n
 
 
 # get scenerio 4
@@ -41,20 +39,20 @@ x <- seq(1, n, 1)
 # x<- cos(6*pi*x/n)
 
 # get scenario 6
-x<- x*0
+# x<- x*0
 
 # get the simulated heterogeneously-smooth data
 x_j <- x # we could add permutation for different j.
 
 
 # scenerio 6
-get_g_j <- function(x_j, j){
-  g_0 <- (x_j + 0.1)*(j/10)
-  g_0_n <- norm(g_0, type="2")/sqrt(n)
-  a_j <- 1/g_0_n
-  g_0 <- a_j**(x_j + 0.1)*(j/10)
-  return(g_0)
-}
+# get_g_j <- function(x_j, j){
+#   g_0 <- (x_j + 0.1)*(j/10)
+#   g_0_n <- norm(g_0, type="2")/sqrt(n)
+#   a_j <- 1/g_0_n
+#   g_0 <- a_j**(x_j + 0.1)*(j/10)
+#   return(g_0)
+# }
 
 # scenerio 5
 # get_g_j <- function(x_j, j){
@@ -76,14 +74,14 @@ get_g_j <- function(x_j, j){
 # }
 
 
-# # scenerio 1, 2, 3, Doppler-like
-# get_g_j <- function(x_j, j){
-#   g_0 <- sin(2*pi/(x_j + 0.1)**(j/10))
-#   g_0_n <- norm(g_0, type="2")/sqrt(n)
-#   a_j <- 1/g_0_n
-#   g_0 <- a_j*sin(2*pi/(x_j + 0.1)**(j/10))
-#   return(g_0)
-# }
+# scenerio 1, 2, 3, Doppler-like
+get_g_j <- function(x_j, j){
+  g_0 <- sin(2*pi/(x_j + 0.1)**(j/10))
+  g_0_n <- norm(g_0, type="2")/sqrt(n)
+  a_j <- 1/g_0_n
+  g_0 <- a_j*sin(2*pi/(x_j + 0.1)**(j/10))
+  return(g_0)
+}
 
 
 
@@ -102,119 +100,128 @@ y_list <- unname(y_list)
 y_star <- colSums(y_list)
 #get the y_i
 # get other scenerios error
-# sce1 <- rnorm(n, 0, 1)
-# sce2 <- rcauchy(n, 0, 1)
+sce1 <- rnorm(n, 0, 1)
+sce2 <- rcauchy(n, 0, 1)
 # e <- x**0.5/n**0.5
 # te <- rt(n, 2)
 # sce3 <- e*te
 # sce4 <- rt(n,3)
 # sce5 <- rcauchy(n, 0, 1)
-# y <- y_star + sce1
+y <- y_star + sce1
 
 # get scenerio 6 error
-half <- n/2
-x[1:half] <- (0.25*(x[1:half]/n)**0.5 + 1.375)/3
-x <- replace(x, seq(half+1, n, 1), (7*(tail(x,half)/n)**0.5-2)/3)
-sce6 <-rt(n,2)
-sce6_9q <- qt(0.9, 2)
-y<-y_star+x*sce6
-y_9q <- y_star+x*sce6_9q
-plot(y_9q, type="l", col="black", ylab='0.9 quantile')
+# half <- n/2
+# x[1:half] <- (0.25*(x[1:half]/n)**0.5 + 1.375)/3
+# x <- replace(x, seq(half+1, n, 1), (7*(tail(x,half)/n)**0.5-2)/3)
+# sce6 <-rt(n,2)
+# sce6_9q <- qt(0.9, 2)
+# y<-y_star+x*sce6
+# y_9q <- y_star+x*sce6_9q
+# plot(y_9q, type="l", col="black", ylab='0.9 quantile')
 
 
-y_mean <- mean(y)
 
-get_mse <- function(k, alpha = 0.0001, max_t = 50){
-  zero_matrix <- matrix(0, nrow = n, ncol = d)
-  trend_list <- as.data.frame(zero_matrix) 
-  # we initialize all component functions to be 0
+# Worth passing in x, y, and y_star? 
+get_mse <- function(k, alpha = 10**-6, max_t = 50){
+  lambda_list <- 10**seq(5, -10, length.out=100)
+  y_mean <- mean(y)
   
-  trend_hat_prev <- rep(0, times = n)
-  t <- 1
+  best_mse <- Inf 
+  best_lambda <- Inf
+  best_trend_hat <- rep(0, times = n)
   
-  repeat {
-    for (j in 1:d){
-      # calculate jth partial residual using components not equal to j
-      resp <- y - t(rowSums(trend_list[, -j]))
-      fit_matrix <- trendfilter(resp, ord=k)$fit 
-      mses<-apply(fit_matrix,2,MSE,b=resp)
-      print(mses)
-      trend_list[, j] <- fit_matrix[,which.min(mses)]
-    }
+  for (lambda in lambda_list) {
+    zero_matrix <- as.data.frame(matrix(0, nrow = n, ncol = d)) 
+    trend_list <- as.data.frame(zero_matrix) 
+    # we initialize all component functions to be 0
     
-    trend_hat <- rowSums(trend_list)
-    
-    if (all((abs(trend_hat - trend_hat_prev) <= alpha))) {
-      cat("terminating after ", t, "iterations from convergence\n")
-      break
-    } 
-    else if (t >= max_t) {
-      cat("terminating manually after ", t, "iterations\n")
-      break
-    }
-    trend_hat_prev <- trend_hat
-    cat("after ", t, " iterations MSE = ", MSE(y_star, trend_hat), "\n")
-    t <- t + 1
-  }
-  return(MSE(y_star, trend_hat))
-}
-
-
-
-get_mse_q <- function(k, alpha = 0.0001, max_t = 50){
-  zero_matrix <- matrix(0, nrow = n, ncol = d)
-  q_trend_list <- as.data.frame(zero_matrix) 
-  # we initialize all component functions to be 0
-  
-  q_trend_hat_prev <- rep(0, times = n)
-  t <- 1
-  
-  repeat {
-    for (j in 1:d){
-      # calculate jth partial residual using components not equal to j
-      resp <- y - as.numeric(t(rowSums(q_trend_list[, -j])))
-      old_MSE <- Inf
-      for (lambda in lambda_list) {
-        fit <- get_trend(resp, tau, lambda, k)
-        if (MSE(fit, resp) < old_MSE) {
-          best_fit <- fit
-          old_MSE <- MSE(fit, resp)
-        }  
+    trend_hat_prev <- rep(0, times = n)
+    t <- 1
+    repeat {
+      for (j in 1:d){
+        # calculate jth partial residual using components not equal to j
+        resp <- y - y_mean - as.numeric(t(rowSums(trend_list[, -j])))
+        trend_list[, j] <- as.numeric(trendfilter(x, resp, k = k, lambda = lambda)$beta)
       }
-      q_trend_list[, j] <- best_fit
+      trend_hat <- rowSums(trend_list)
+      
+      if (all((abs(trend_hat - trend_hat_prev) <= alpha))) {break}
+      else if (t >= max_t) {break}
+      
+      trend_hat_prev <- trend_hat
+      t <- t + 1
     }
     
-    q_trend_hat <- rowSums(q_trend_list)
-    
-    if (all(abs(q_trend_hat - q_trend_hat_prev) <= alpha)) {
-      cat("terminating after ", t, "iterations from convergence\n")
-      break
-    } 
-    else if (t >= max_t) {
-      cat("terminating manually after ", t, "iterations\n")
-      break
+    current_mse <- MSE(y_star, trend_hat + y_mean) 
+    cat("lambda of ", lambda, " achieved true MSE of ", current_mse, "\n")
+    if (current_mse < best_mse) {
+      best_mse <- current_mse
+      best_lambda <- lambda
+      best_trend_hat <- trend_hat
     }
-    q_trend_hat_prev <- q_trend_hat
-    cat("after ", t, " iterations MSE = ", MSE(y_star, q_trend_hat), "\n")
-    t <- t + 1
   }
-  return(MSE(y_star, q_trend_hat))
+  
+  return(list("MSE" = best_mse, "LAMBDA" = best_lambda, "FIT" = best_trend_hat))
 }
 
 
-ATF2 = get_mse(k=2)
-ATF2
-QATF2 = get_mse_q(k=2)
-QATF2
-ATF3 = get_mse(k=3)
-ATF3
-QATF3 = get_mse_q(k=3)
-QATF3
+# Worth passing in x, y, and y_star? 
+
+get_mse_q <- function(k, alpha = 10**-6, max_t = 50){
+  lambda_list <- 10**seq(5, -10, length.out=100)
+  
+  best_mse <- Inf 
+  best_lambda <- Inf
+  best_q_trend_hat <- rep(0, times = n)
+  
+  for (lambda in lambda_list) {
+    q_trend_list <- as.data.frame(matrix(0, nrow = n, ncol = d)) 
+    # we initialize all component functions to be 0
+    
+    q_trend_hat_prev <- rep(0, times = n)
+    t <- 1
+    repeat {
+      for (j in 1:d){
+        # calculate jth partial residual using components not equal to j
+        resp <- y - as.numeric(t(rowSums(q_trend_list[, -j])))
+        q_trend_list[, j] <- get_trend(resp, tau, lambda, k)
+      }
+      q_trend_hat <- rowSums(q_trend_list)
+      
+      if (all((abs(q_trend_hat - q_trend_hat_prev) <= alpha))) {break}
+      else if (t >= max_t) {break}
+      
+      q_trend_hat_prev <- q_trend_hat
+      t <- t + 1
+    }
+    
+    current_mse <- MSE(y_star, q_trend_hat) 
+    cat("lambda of ", lambda, " achieved true MSE of ", current_mse, "\n")
+    
+    if (current_mse < best_mse) {
+      best_mse <- current_mse
+      best_lambda <- lambda
+      best_q_trend_hat <- q_trend_hat
+    }
+  }
+  return(list("MSE" = best_mse, "LAMBDA" = best_lambda, "FIT" = best_q_trend_hat))
+}
 
 
-data = data.frame(n = n, Scenario = 6,
-                  tau=tau, QATF2 = QATF2, QATF3 = QATF3,
-                  ATF2 =ATF2, ATF3 =ATF3)
+ATF2 <- get_mse(2)
+ATF3 <- get_mse(3)
+QATF2 <- get_mse_q(2)
+QATF3 <- get_mse_q(3)
+
+cat(ATF2$MSE, "at lambda : ", ATF2$LAMBDA, "\n")
+cat(ATF3$MSE, "at lambda : ", ATF3$LAMBDA, "\n")
+cat(QATF2$MSE, "at lambda : ", QATF2$LAMBDA, "\n")
+cat(QATF3$MSE, "at lambda : ", QATF3$LAMBDA, "\n")
+
+
+data <- data.frame(n = n, Scenario = 1,
+                  tau=tau, QATF2 = QATF2$MSE, QATF3 = QATF3$MSE,
+                  ATF2 =ATF2$MSE, ATF3 =ATF3$MSE)
 
 # write data to a sample.csv file
 write.table(data, file = "~/QATF/sample2.csv", append = TRUE, quote = FALSE,

--- a/qatf.R
+++ b/qatf.R
@@ -1,19 +1,21 @@
 # install.packages("devtools")
-# library(devtools)
-# install_github("zzh237/detrendr")
-# install_github("glmgen/genlasso")
-# library(detrendr)
-# library(genlasso)
+library(devtools)
+install_github("zzh237/detrendr")
+install_github("glmgen/genlasso")
+# not sure if this next one is necessary - Zhi can you check? 
+# install_github("statsmaths/glmgen", subdir="R_pkg/glmgen")
+
+library(detrendr)
 # trace(get_model, edit=TRUE)
+library(genlasso)
+library(glmgen)
+
 MSE <- function(a, b){
   len = length(a)
   return(norm(a - b, type="2")**2/len) 
 }
 
-## Need a model selection that penalizes overfitting for our univariate usage
-
-
-lambda_list <- 10**seq(-1, 4.5, length.out=300)
+lambda_list <- 10**seq(-3, 4.5, length.out=50)
 
 lambda <- 5
 tau <- c(0.9)


### PR DESCRIPTION
Lambda selection
- Switch trendfilter to the glmgen version, allowing for a single specified lambda fit (genlasso only gives the solution path). 
- get_mse constructs lambda list. Currently fitting on 100 values from 10^ 5 to 10 ^ -10. So far I've noticed QATF likes larger values of lambda than ATF, making using a single function of n and k difficult. 
- Do backfitting for fixed lambda
- Select lambda by evaluating backfit mse for each lambda